### PR TITLE
feature: supabase storage 연동

### DIFF
--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -1,0 +1,1 @@
+export const STORAGE_BUCKET = 'heejung';

--- a/src/hooks/use-storage-image.ts
+++ b/src/hooks/use-storage-image.ts
@@ -11,7 +11,6 @@ export const useStorageImage = (path: string) => {
     let objectUrl = '';
 
     const loadImage = async () => {
-      console.log('loadImage: ' + STORAGE_BUCKET + '/' + path);
       const { data, error } = await supabase.storage
         .from(STORAGE_BUCKET)
         .download(path);

--- a/src/hooks/use-storage-image.ts
+++ b/src/hooks/use-storage-image.ts
@@ -1,0 +1,34 @@
+import { STORAGE_BUCKET } from '@/constants/storage';
+import { supabase } from '@/lib/supabase';
+import { useState, useEffect } from 'react';
+
+export const useStorageImage = (path: string) => {
+  const [url, setUrl] = useState<string>('');
+
+  useEffect(() => {
+    if (!path) return;
+
+    let objectUrl = '';
+
+    const loadImage = async () => {
+      console.log('loadImage: ' + STORAGE_BUCKET + '/' + path);
+      const { data, error } = await supabase.storage
+        .from(STORAGE_BUCKET)
+        .download(path);
+      if (data) {
+        objectUrl = URL.createObjectURL(data);
+        setUrl(objectUrl);
+      } else {
+        console.error('이미지 다운로드 실패:', error?.message);
+      }
+    };
+
+    loadImage();
+
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [path]);
+
+  return url;
+};

--- a/src/pages/onboarding/vote-section/voted-section.tsx
+++ b/src/pages/onboarding/vote-section/voted-section.tsx
@@ -5,6 +5,7 @@ import {
   TrendingUpIcon,
 } from 'lucide-react';
 import { VoteActionButton } from './vote-action-button';
+import { useStorageImage } from '@/hooks/use-storage-image';
 
 interface VotedSectionProps {
   backgroundColor?: string;
@@ -23,6 +24,8 @@ export const VotedSection = ({
     rank: 1,
     trend: '+5.2%',
   };
+
+  const partyImageUrl = useStorageImage('party/ppp.svg'); // TODO: sample image, 정리 예쩡
 
   return (
     <div
@@ -47,9 +50,11 @@ export const VotedSection = ({
         {/* 정당 정보 */}
         <div className='mb-6'>
           <div className='mb-2 flex items-center gap-4'>
-            <div className='flex h-16 w-16 items-center justify-center rounded-full bg-white/20 text-2xl font-bold'>
-              민
-            </div>
+            <img
+              src={partyImageUrl}
+              alt='party-image'
+              className='h-16 w-16 rounded-full bg-white p-2'
+            />
             <div>
               <h2 className='text-2xl font-bold'>{selectedParty.name}</h2>
               <p className='text-blue-100'>{selectedParty.englishName}</p>


### PR DESCRIPTION
## 작업내용
- supabase storage 연동하는 use-storage-image hook 추가
    - path('folder/file_name')를 파라미터로 받아서 이미지 blob url 반환
- voted-section 컴포넌트에 정당 샘플 이미지 추가